### PR TITLE
Support channel_id_changed events

### DIFF
--- a/slackevents/inner_events.go
+++ b/slackevents/inner_events.go
@@ -47,6 +47,14 @@ type AppUninstalledEvent struct {
 	Type string `json:"type"`
 }
 
+// ChannelIDChangedEvent A channel ID has changed after being shared externally.
+type ChannelIDChangedEvent struct {
+	Type           string      `json:"type"`
+	OldChannelID   string      `json:"old_channel_id"`
+	NewChannelID   string      `json:"new_channel_id"`
+	EventTimeStamp json.Number `json:"event_ts"`
+}
+
 // GridMigrationFinishedEvent An enterprise grid migration has finished on this workspace.
 type GridMigrationFinishedEvent struct {
 	Type         string `json:"type"`
@@ -310,6 +318,8 @@ const (
 	AppHomeOpened = "app_home_opened"
 	// AppUninstalled Your Slack app was uninstalled.
 	AppUninstalled = "app_uninstalled"
+	// ChannelIDChangedEvent A channel ID has changed after being shared externally.
+	ChannelIDChanged = "channel_id_changed"
 	// GridMigrationFinished An enterprise grid migration has finished on this workspace.
 	GridMigrationFinished = "grid_migration_finished"
 	// GridMigrationStarted An enterprise grid migration has started on this workspace.
@@ -343,6 +353,7 @@ var EventsAPIInnerEventMapping = map[string]interface{}{
 	AppMention:            AppMentionEvent{},
 	AppHomeOpened:         AppHomeOpenedEvent{},
 	AppUninstalled:        AppUninstalledEvent{},
+	ChannelIDChanged:      ChannelIDChangedEvent{},
 	GridMigrationFinished: GridMigrationFinishedEvent{},
 	GridMigrationStarted:  GridMigrationStartedEvent{},
 	LinkShared:            LinkSharedEvent{},

--- a/slackevents/inner_events_test.go
+++ b/slackevents/inner_events_test.go
@@ -38,6 +38,21 @@ func TestAppUninstalled(t *testing.T) {
 	}
 }
 
+func TestChannelIDChanged(t *testing.T) {
+	rawE := []byte(`
+		{
+			"type": "channel_id_changed",
+			"old_channel_id": "G012Y48650T",
+			"new_channel_id": "C012Y48650T",
+			"event_ts": "1612206778.000000"
+		}
+	`)
+	err := json.Unmarshal(rawE, &ChannelIDChangedEvent{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestGridMigrationFinishedEvent(t *testing.T) {
 	rawE := []byte(`
 			{


### PR DESCRIPTION
- Adds support for [channel_id_changed events](https://api.slack.com/events/channel_id_changed).
- It was recommended by original library maintainers to just create a fork for this: https://github.com/slack-go/slack/issues/909
- We want this for https://github.com/range-labs/mono/issues/8954